### PR TITLE
Update to 1.2.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "fastcluster" %}
-{% set version = "1.1.26" %}
-{% set sha256 = "a202f44a3b06f5cf9cdba3c67d6c523288922d6e6a1cdf737292f93759aa82f7" %}
+{% set version = "1.2.4" %}
+{% set sha256 = "b5697a26b5397004bba4ac6308e9e9b7a832dcccfcc0333554bc3898a55601a3" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -21,8 +21,9 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
+    - numpy >=1.9
     - setuptools
-    - numpy
+    - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -33,9 +34,9 @@ test:
 
 about:
   home: http://danifold.net/fastcluster.html
-  license: BSD-2-Clause
+  license: BSD-2-Clause AND GPL-2.0-or-later
   license_file: COPYING.txt
-  summary: 'Fast hierarchical clustering routines for R and Python.'
+  summary: Fast hierarchical clustering routines for R and Python.
   description: |
     This library provides Python functions for hierarchical clustering. It generates hierarchical
     clusters from distance matrices or from vector data.


### PR DESCRIPTION
Popularity:  340656 downloads -  fastcluster  1.1.26  Fast hierarchical clustering routines for R and Python.
Requirements from conda-forge: https://github.com/conda-forge/fastcluster-feedstock/blob/master/recipe/meta.yaml
  license: BSD-2-Clause
Release date:  Aug 22, 2021, https://pypi.org/project/fastcluster/#history
Bug Tracker: new open issues https://github.com/dmuellner/fastcluster/issues
Github releases:  https://github.com/dmuellner/fastcluster/releases
Upstream license: https://github.com/dmuellner/fastcluster/blob/master/COPYING.txt and https://github.com/dmuellner/fastcluster/blob/25e38b9da00b3c39fe867c1229c28e96e3608a60/setup.py#L127
Upstream changelog:
Upstream setup file: https://github.com/dmuellner/fastcluster/blob/v1.2.4/setup.py


Actions:
1. Add missing package wheel
2. Update the License. But its not clear that both licenses are actual. PYPI also mentioned both https://pypi.org/project/fastcluster/1.2.4/
3. Update sha256, version and build number to 0.
4. Update dependencies: `numpy >=1.9`, see https://github.com/dmuellner/fastcluster/blob/25e38b9da00b3c39fe867c1229c28e96e3608a60/setup.py#L87

Result:
- all-succeeded on concourse
