### PR TITLE
Update to 1.1.26

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "fastcluster" %}
-{% set version = "1.2.4" %}
-{% set sha256 = "b5697a26b5397004bba4ac6308e9e9b7a832dcccfcc0333554bc3898a55601a3" %}
+{% set version = "1.1.26" %}
+{% set sha256 = "a202f44a3b06f5cf9cdba3c67d6c523288922d6e6a1cdf737292f93759aa82f7" %}
 
 package:
   name: {{ name|lower }}
@@ -34,18 +34,16 @@ test:
 
 about:
   home: http://danifold.net/fastcluster.html
-  license: BSD-2-Clause AND GPL-2.0-or-later
+  license: BSD-2-Clause
   license_file: COPYING.txt
   summary: Fast hierarchical clustering routines for R and Python.
   description: |
     This library provides Python functions for hierarchical clustering. It generates hierarchical
     clusters from distance matrices or from vector data.
-
     Part of this module is intended to replace the functions
     linkage, single, complete, average, weighted, centroid, median, ward
     in the module scipy.cluster.hierarchy with the same functionality but much faster algorithms.
     Moreover, the function linkage_vector provides memory-efficient clustering for vector data.
-
     The interface is very similar to MATLAB’s Statistics Toolbox API to make code easier to
     port from MATLAB to Python/NumPy. The core implementation of this library is in C++ for efficiency.
   dev_url: https://github.com/dmuellner/fastcluster
@@ -54,3 +52,4 @@ about:
 extra:
   recipe-maintainers:
     - mpharrigan
+    

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
 
 about:
   home: http://danifold.net/fastcluster.html
-  license: BSD-2-Clause
+  license: BSD-2-Clause AND GPL-2.0-or-later
   license_file: COPYING.txt
   summary: Fast hierarchical clustering routines for R and Python.
   description: |
@@ -52,4 +52,3 @@ about:
 extra:
   recipe-maintainers:
     - mpharrigan
-    


### PR DESCRIPTION
Requirements from conda-forge: https://github.com/conda-forge/fastcluster-feedstock/blob/master/recipe/meta.yaml
license: BSD-2-Clause
Upstream license: https://github.com/dmuellner/fastcluster/blob/v1.1.26/COPYING.txt 
Upstream changelog: https://github.com/dmuellner/fastcluster/blob/v1.1.26/NEWS.txt
Upstream setup file: https://github.com/dmuellner/fastcluster/blob/v1.1.26/setup.py

Actions:

1. Add missing package wheel
2. Update the License.
3. Update sha256 and version.
4. Update dependencies: `numpy >=1.9`

Result:

all-succeeded on concourse